### PR TITLE
Provide function to parse pabulib string

### DIFF
--- a/pabutools/election/pabulib.py
+++ b/pabutools/election/pabulib.py
@@ -22,16 +22,15 @@ from pabutools.election.profile import (
 import csv
 import os
 
-
-def parse_pabulib(file_path: str) -> tuple[Instance, AbstractProfile]:
+def parse_pabulib_from_string(file_content: str) -> tuple[Instance, AbstractProfile]:
     """
-    Parses a PaBuLib files and returns the corresponding instance and profile. The returned profile will be of the
+    Parses a PaBuLib file given as a string and returns the corresponding instance and profile. The returned profile will be of the
     correct type depending on the metadata in the file.
 
     Parameters
     ----------
-        file_path : str
-            Path to the PaBuLib file to be parsed.
+        file_content : str
+            String containing the contents of the PaBuLib file to be parsed.
 
     Returns
     -------
@@ -41,92 +40,90 @@ def parse_pabulib(file_path: str) -> tuple[Instance, AbstractProfile]:
     instance = Instance()
     ballots = []
     optional_sets = {"categories": set(), "targets": set()}
-    instance.file_path = file_path
-    instance.file_name = os.path.basename(file_path)
-
-    with open(file_path, "r", newline="", encoding="utf-8-sig") as csvfile:
-        section = ""
-        header = []
-        reader = csv.reader(csvfile, delimiter=";")
-        for row in reader:
-            if len(row) == 1 and len(row[0].strip()) == 0:
-                continue
-            if str(row[0]).strip().lower() in ["meta", "projects", "votes"]:
-                section = str(row[0]).strip().lower()
-                header = next(reader)
-            elif section == "meta":
-                instance.meta[row[0].strip()] = row[1].strip()
-            elif section == "projects":
-                p = Project()
-                project_meta = dict()
-                for i in range(len(row)):
-                    key = header[i].strip()
-                    p.name = row[0].strip()
-                    if row[i].strip().lower() != "none":
-                        if key in ["category", "categories"]:
-                            project_meta["categories"] = [
-                                entry.strip() for entry in row[i].split(",")
-                            ]
-                            p.categories = set(project_meta["categories"])
-                            optional_sets["categories"].update(
-                                project_meta["categories"]
-                            )
-                        elif key in ["target", "targets"]:
-                            project_meta["targets"] = [
-                                entry.strip() for entry in row[i].split(",")
-                            ]
-                            p.targets = set(project_meta["targets"])
-                            optional_sets["targets"].update(project_meta["targets"])
-                        else:
-                            project_meta[key] = row[i].strip()
-                p.cost = str_as_frac(project_meta["cost"].replace(",", "."))
-                instance.add(p)
-                instance.project_meta[p] = project_meta
-            elif section == "votes":
-                ballot_meta = dict()
-                for i in range(len(row)):
-                    if row[i].strip().lower() != "none":
-                        ballot_meta[header[i].strip()] = row[i].strip()
-                if instance.meta["vote_type"] == "approval":
-                    ballot = ApprovalBallot()
-                    for project_name in ballot_meta["vote"].split(","):
-                        ballot.add(instance.get_project(project_name))
-                    ballot_meta.pop("vote")
-                elif instance.meta["vote_type"] == "scoring":
-                    ballot = CardinalBallot()
-                    points = ballot_meta["points"].split(",")
-                    for index, project_name in enumerate(
-                        ballot_meta["vote"].split(",")
-                    ):
-                        ballot[instance.get_project(project_name)] = str_as_frac(
-                            points[index].strip()
+    
+    lines = file_content.splitlines()
+    section = ""
+    header = []
+    reader = csv.reader(lines, delimiter=";")
+    for row in reader:
+        if len(row) == 1 and len(row[0].strip()) == 0:
+            continue
+        if str(row[0]).strip().lower() in ["meta", "projects", "votes"]:
+            section = str(row[0]).strip().lower()
+            header = next(reader)
+        elif section == "meta":
+            instance.meta[row[0].strip()] = row[1].strip()
+        elif section == "projects":
+            p = Project()
+            project_meta = dict()
+            for i in range(len(row)):
+                key = header[i].strip()
+                p.name = row[0].strip()
+                if row[i].strip().lower() != "none":
+                    if key in ["category", "categories"]:
+                        project_meta["categories"] = [
+                            entry.strip() for entry in row[i].split(",")
+                        ]
+                        p.categories = set(project_meta["categories"])
+                        optional_sets["categories"].update(
+                            project_meta["categories"]
                         )
-                    ballot_meta.pop("vote")
-                    ballot_meta.pop("points")
-                elif instance.meta["vote_type"] == "cumulative":
-                    ballot = CumulativeBallot()
-                    points = ballot_meta["points"].split(",")
-                    for index, project_name in enumerate(
-                        ballot_meta["vote"].split(",")
-                    ):
-                        ballot[instance.get_project(project_name)] = str_as_frac(
-                            points[index].strip()
-                        )
-                    ballot_meta.pop("vote")
-                    ballot_meta.pop("points")
-                elif instance.meta["vote_type"] == "ordinal":
-                    ballot = OrdinalBallot()
-                    for project_name in ballot_meta["vote"].split(","):
-                        ballot.append(instance.get_project(project_name))
-                    ballot_meta.pop("vote")
-                else:
-                    raise NotImplementedError(
-                        "The PaBuLib parser cannot parse {} profiles for now.".format(
-                            instance.meta["vote_type"]
-                        )
+                    elif key in ["target", "targets"]:
+                        project_meta["targets"] = [
+                            entry.strip() for entry in row[i].split(",")
+                        ]
+                        p.targets = set(project_meta["targets"])
+                        optional_sets["targets"].update(project_meta["targets"])
+                    else:
+                        project_meta[key] = row[i].strip()
+            p.cost = str_as_frac(project_meta["cost"].replace(",", "."))
+            instance.add(p)
+            instance.project_meta[p] = project_meta
+        elif section == "votes":
+            ballot_meta = dict()
+            for i in range(len(row)):
+                if row[i].strip().lower() != "none":
+                    ballot_meta[header[i].strip()] = row[i].strip()
+            if instance.meta["vote_type"] == "approval":
+                ballot = ApprovalBallot()
+                for project_name in ballot_meta["vote"].split(","):
+                    ballot.add(instance.get_project(project_name))
+                ballot_meta.pop("vote")
+            elif instance.meta["vote_type"] == "scoring":
+                ballot = CardinalBallot()
+                points = ballot_meta["points"].split(",")
+                for index, project_name in enumerate(
+                    ballot_meta["vote"].split(",")
+                ):
+                    ballot[instance.get_project(project_name)] = str_as_frac(
+                        points[index].strip()
                     )
-                ballot.meta = ballot_meta
-                ballots.append(ballot)
+                ballot_meta.pop("vote")
+                ballot_meta.pop("points")
+            elif instance.meta["vote_type"] == "cumulative":
+                ballot = CumulativeBallot()
+                points = ballot_meta["points"].split(",")
+                for index, project_name in enumerate(
+                    ballot_meta["vote"].split(",")
+                ):
+                    ballot[instance.get_project(project_name)] = str_as_frac(
+                        points[index].strip()
+                    )
+                ballot_meta.pop("vote")
+                ballot_meta.pop("points")
+            elif instance.meta["vote_type"] == "ordinal":
+                ballot = OrdinalBallot()
+                for project_name in ballot_meta["vote"].split(","):
+                    ballot.append(instance.get_project(project_name))
+                ballot_meta.pop("vote")
+            else:
+                raise NotImplementedError(
+                    "The PaBuLib parser cannot parse {} profiles for now.".format(
+                        instance.meta["vote_type"]
+                    )
+                )
+            ballot.meta = ballot_meta
+            ballots.append(ballot)
 
     legal_min_length = instance.meta.get("min_length", None)
     if legal_min_length is not None:
@@ -207,5 +204,29 @@ def parse_pabulib(file_path: str) -> tuple[Instance, AbstractProfile]:
     # We add the category and target information that we collected from the projects
     instance.categories = optional_sets["categories"]
     instance.targets = optional_sets["targets"]
+
+    return instance, profile
+
+def parse_pabulib(file_path: str) -> tuple[Instance, AbstractProfile]:
+    """
+    Parses a PaBuLib files and returns the corresponding instance and profile. The returned profile will be of the
+    correct type depending on the metadata in the file.
+
+    Parameters
+    ----------
+        file_path : str
+            Path to the PaBuLib file to be parsed.
+
+    Returns
+    -------
+        tuple[:py:class:`~pabutools.election.instance.Instance`, :py:class:`~pabutools.election.profile.profile.Profile`]
+            The instance and the profile corresponding to the file.
+    """
+    
+    with open(file_path, "r", newline="", encoding="utf-8-sig") as csvfile:
+        instance, profile = parse_pabulib_from_string(csvfile.read())
+
+    instance.file_path = file_path
+    instance.file_name = os.path.basename(file_path)
 
     return instance, profile

--- a/tests/test_pabulib.py
+++ b/tests/test_pabulib.py
@@ -1,16 +1,14 @@
 from unittest import TestCase
 
 from pabutools.election import OrdinalBallot
-from pabutools.election.pabulib import parse_pabulib
+from pabutools.election.pabulib import parse_pabulib, parse_pabulib_from_string
 
 import os
 
 
 class TestPabulib(TestCase):
     def test_approval(self):
-        with open("test.pb", "w", encoding="utf-8") as f:
-            f.write(
-                """META
+        contents = """META
 key;value
 description;Local PB in Warsaw, WesoÅ‚a | Plac Wojska Polskiego
 country;Poland
@@ -64,27 +62,28 @@ voter_id;age;sex;voting_method;vote
 94116;33;M;internet;427
 103942;54;M;internet;427
 104255;53;F;internet;427"""
-            )
 
-        instance, profile = parse_pabulib("test.pb")
+        with open("test.pb", "w", encoding="utf-8") as f:
+            f.write(contents)
+
+        for instance, profile in [parse_pabulib("test.pb"), parse_pabulib_from_string(contents)]:
+            assert len(instance) == 4
+            assert instance.budget_limit == 51195
+            assert len(profile) == 27
+            assert len(profile[0]) == 1
+            assert len(profile[4]) == 4
+            for p in profile[0]:
+                assert p.name == "427"
+                assert p.cost == 15995
+            assert profile.approval_score(instance.get_project("427")) == 16
+            assert len(profile.approved_projects()) == 4
+            assert len(instance.categories) == 5
+            assert len(instance.targets) == 5
+
         os.remove("test.pb")
-        assert len(instance) == 4
-        assert instance.budget_limit == 51195
-        assert len(profile) == 27
-        assert len(profile[0]) == 1
-        assert len(profile[4]) == 4
-        for p in profile[0]:
-            assert p.name == "427"
-            assert p.cost == 15995
-        assert profile.approval_score(instance.get_project("427")) == 16
-        assert len(profile.approved_projects()) == 4
-        assert len(instance.categories) == 5
-        assert len(instance.targets) == 5
 
     def test_cumulative(self):
-        with open("test.pb", "w", encoding="utf-8") as f:
-            f.write(
-                """META
+        contents = """META
 key;value
 description;Municipal PB in Toulouse
 country;France
@@ -147,33 +146,34 @@ voter_id;vote;points
 9;1,6,7,9,10,20,30;1,1,1,1,1,1,1
 10;6,7;3,3
 11;2,14,8;3,3,1"""
-            )
+        
+        with open("test.pb", "w", encoding="utf-8") as f:
+            f.write(contents)
 
-        instance, profile = parse_pabulib("test.pb")
+        for instance, profile in [parse_pabulib("test.pb"), parse_pabulib_from_string(contents)]:
+            assert len(instance) == 30
+            assert instance.budget_limit == 1000000
+            assert len(profile) == 12
+            assert len(profile[0]) == 4
+            assert len(profile[4]) == 5
+
+            projects = {i: instance.get_project(str(i)) for i in range(1, 31)}
+            assert profile[0][projects[9]] == 1
+            assert profile[0][projects[10]] == 2
+            assert profile[0][projects[11]] == 2
+            assert profile[0][projects[13]] == 2
+            assert profile[4][projects[5]] == 3
+            assert profile[4][projects[10]] == 1
+            assert profile[4][projects[11]] == 1
+            assert profile[4][projects[13]] == 1
+            assert profile[4][projects[20]] == 1
+            assert len(instance.categories) == 0
+            assert len(instance.targets) == 0
+
         os.remove("test.pb")
-        assert len(instance) == 30
-        assert instance.budget_limit == 1000000
-        assert len(profile) == 12
-        assert len(profile[0]) == 4
-        assert len(profile[4]) == 5
-
-        projects = {i: instance.get_project(str(i)) for i in range(1, 31)}
-        assert profile[0][projects[9]] == 1
-        assert profile[0][projects[10]] == 2
-        assert profile[0][projects[11]] == 2
-        assert profile[0][projects[13]] == 2
-        assert profile[4][projects[5]] == 3
-        assert profile[4][projects[10]] == 1
-        assert profile[4][projects[11]] == 1
-        assert profile[4][projects[13]] == 1
-        assert profile[4][projects[20]] == 1
-        assert len(instance.categories) == 0
-        assert len(instance.targets) == 0
 
     def test_scoring(self):
-        with open("test.pb", "w", encoding="utf-8") as f:
-            f.write(
-                """META
+        contents = """META
 key;value
 description;Municipal PB in Toulouse
 country;France
@@ -234,19 +234,19 @@ voter_id;vote;points
 9;1,6,7,9,10,20,30;1,1,1,1,1,1,1
 10;6,7;3,3
 11;2,14,8;3,3,1"""
-            )
 
-        instance, profile = parse_pabulib("test.pb")
+        with open("test.pb", "w", encoding="utf-8") as f:
+            f.write(contents)
+
+        for instance, profile in [parse_pabulib("test.pb"), parse_pabulib_from_string(contents)]:
+            assert profile[0][instance.get_project("10")] == 2
+            assert profile[0][instance.get_project("9")] == 1
+            assert profile[11][instance.get_project("8")] == 1
+
         os.remove("test.pb")
 
-        assert profile[0][instance.get_project("10")] == 2
-        assert profile[0][instance.get_project("9")] == 1
-        assert profile[11][instance.get_project("8")] == 1
-
     def test_ordinal(self):
-        with open("test.pb", "w", encoding="utf-8") as f:
-            f.write(
-                """META
+        contents = """META
 key;value
 description;Municipal PB in Kraków
 country;Poland
@@ -436,28 +436,29 @@ voter_id;vote;voting_method;district
 43;84,101,83;internet;PODGÓRZE
 44;4,36,41;internet;KROWODRZA
 """
+        
+        with open("test.pb", "w", encoding="utf-8") as f:
+            f.write(contents)
+
+        for instance, profile in [parse_pabulib("test.pb"), parse_pabulib_from_string(contents)]:
+            assert len(instance) == 123
+            assert instance.budget_limit == 8000100
+            assert len(profile) == 45
+            assert len(profile[44]) == 3
+            assert len(profile[4]) == 3
+
+            assert profile[44] == OrdinalBallot(
+                [
+                    instance.get_project("4"),
+                    instance.get_project("36"),
+                    instance.get_project("41"),
+                ]
             )
 
-        instance, profile = parse_pabulib("test.pb")
         os.remove("test.pb")
-        assert len(instance) == 123
-        assert instance.budget_limit == 8000100
-        assert len(profile) == 45
-        assert len(profile[44]) == 3
-        assert len(profile[4]) == 3
-
-        assert profile[44] == OrdinalBallot(
-            [
-                instance.get_project("4"),
-                instance.get_project("36"),
-                instance.get_project("41"),
-            ]
-        )
 
     def test_wrong_type(self):
-        with open("test.pb", "w", encoding="utf-8") as f:
-            f.write(
-                """META
+        contents = """META
                 key;value
                 description;Municipal PB in Kraków
                 country;Poland
@@ -490,7 +491,8 @@ voter_id;vote;voting_method;district
                 3;18,3,34;internet;CZYŻYNY
                 4;97,120,117;paper;NOWA HUTA
             """
-            )
+        with open("test.pb", "w", encoding="utf-8") as f:
+            f.write(contents)
 
         try:
             _, _ = parse_pabulib("test.pb")
@@ -500,9 +502,7 @@ voter_id;vote;voting_method;district
             os.remove("test.pb")
 
     def test_legal_defaults(self):
-        with open("test.pb", "w", encoding="utf-8") as f:
-            f.write(
-                """META
+        contents = """META
                 key;value
                 description;Municipal PB in Kraków
                 country;Poland
@@ -527,7 +527,8 @@ voter_id;vote;voting_method;district
                 voter_id;vote;voting_method;district
                 0;1,2,3;paper;PODGÓRZE DUCHACKIE
             """
-            )
+        with open("test.pb", "w", encoding="utf-8") as f:
+            f.write(contents)
         instance, profile = parse_pabulib("test.pb")
         os.remove("test.pb")
         assert instance.meta["min_length"] == "1"
@@ -539,9 +540,7 @@ voter_id;vote;voting_method;district
         assert profile.legal_min_cost is None
         assert profile.legal_max_cost is None
 
-        with open("test.pb", "w", encoding="utf-8") as f:
-            f.write(
-                """META
+        contents = """META
                 key;value
                 description;Municipal PB in Kraków
                 country;Poland
@@ -566,7 +565,8 @@ voter_id;vote;voting_method;district
                 voter_id;vote;points
                 0;1,2,3;1,2,3
             """
-            )
+        with open("test.pb", "w", encoding="utf-8") as f:
+            f.write(contents)
         instance, profile = parse_pabulib("test.pb")
         os.remove("test.pb")
 


### PR DESCRIPTION
Adds a function `parse_pabulib_from_string` that parses a pabulib file given as a string. This allows users to avoid touching the file system, which may be useful if the file comes from an HTTP request.