### PR TITLE
fix Profile, now works when initiated with an iterable

### DIFF
--- a/pabutools/election/profile/profile.py
+++ b/pabutools/election/profile/profile.py
@@ -188,10 +188,11 @@ class Profile(list, AbstractProfile):
             else:
                 instance = Instance()
         AbstractProfile.__init__(self, instance, ballot_validation, ballot_type)
+        init = list(init)  # in case `init` is an iterable 
         if ballot_validation:
             for item in init:
                 self.validate_ballot(item)
-        list.__init__(self, init)
+        super().__init__(init)
 
     def multiplicity(self, ballot: Ballot) -> int:
         """


### PR DESCRIPTION
I stumbled over this problem when using the library.

Issue:
`profile = ApprovalProfile([ApprovalBallot(projects[pn-1] for pn in ballot) for ballot in ballots])` works, while
`profile = ApprovalProfile(ApprovalBallot(projects[pn-1] for pn in ballot) for ballot in ballots)` creates an empty profile (without error).
