### PR TITLE
Bug fix in MES aggregation

### DIFF
--- a/pabutools/fractions.py
+++ b/pabutools/fractions.py
@@ -3,6 +3,8 @@ Module introducing all the functions used to handle fractions.
 """
 from __future__ import annotations
 
+from copy import copy
+
 from typing import TYPE_CHECKING
 
 from gmpy2 import mpq
@@ -54,7 +56,7 @@ def frac(*arg: Numeric) -> Numeric:
             )
     elif len(arg) == 2:
         if FRACTION == "gmpy2":
-            return mpq(arg[0], arg[1])
+            return mpq(copy(arg[0]), copy(arg[1]))
         elif FRACTION == "float":
             return arg[0] / arg[1]
         else:


### PR DESCRIPTION
When using MES, the voters budget is defined by:
`frac(instance.budget_limit, profile.num_ballots())` 
which returns and mpq object.

Then during the aggregation, the function "budget_over_sat_project" is called which use:
`res = frac(self.budget, self.sat.sat_project(proj))`
This results creating a new mpq object when self.budget is also mpq object.
When using mpq with mpq object as argument, the function also change the original object.

A simple examle:
```
a = mpq(1,3)
b = mpq(a, 3)
```
This code will result with both a and b being mpq(1,9).

Simple solution is creating a copy before passing to mpq.