### PR TITLE
Implement exhaustive_stop argument for exhaustion rule

### DIFF
--- a/pabutools/rules/exhaustion.py
+++ b/pabutools/rules/exhaustion.py
@@ -103,6 +103,7 @@ def exhaustion_by_budget_increase(
     rule_params: dict | None = None,
     initial_budget_allocation: Iterable[Project] | None = None,
     resoluteness: bool = True,
+    exhaustive_stop: bool = True,
     budget_step: Numeric | None = None,
     budget_bound: Numeric | None = None,
 ) -> BudgetAllocation | list[BudgetAllocation]:
@@ -127,6 +128,9 @@ def exhaustion_by_budget_increase(
         resoluteness : bool, optional
             Set to `False` to obtain an irresolute outcome, where all tied budget allocations are returned.
             Defaults to True.
+        exhaustive_stop: bool, optional
+            Set to `False` to disable the exhaustive allocation stop condition, leaving only non-feasibility as
+            th stop condition of this rule. Defaults to True.
         budget_step: Numeric
             The step at which the budget is increased. Defaults to 1% of the budget limit.
         budget_bound: Numeric
@@ -161,14 +165,14 @@ def exhaustion_by_budget_increase(
         if resoluteness:
             if not instance.is_feasible(outcome):
                 return previous_outcome
-            if instance.is_exhaustive(outcome):
+            if exhaustive_stop and instance.is_exhaustive(outcome):
                 return outcome
             current_instance.budget_limit += budget_step
             previous_outcome = outcome
         else:
             if any(not instance.is_feasible(o) for o in outcome):
                 return previous_outcome
-            if any(instance.is_exhaustive(o) for o in outcome):
+            if exhaustive_stop and any(instance.is_exhaustive(o) for o in outcome):
                 return outcome
             current_instance.budget_limit += budget_step
             previous_outcome = outcome

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -310,6 +310,7 @@ class TestAnalysis(TestCase):
             {},
         ]
 
+        assert len(project_losses) == len(projects)
         for idx, project_loss in enumerate(project_losses):
             assert project_loss.name == projects[idx].name
             assert project_loss.supporters_budget == expected_budgets[idx]
@@ -321,12 +322,12 @@ class TestAnalysis(TestCase):
 
     @parameterized.expand(
         [
-            ([1, 1, 2, 1, 2], [200, 150, 37, 75, 50]),
-            ([5, 1, 2, 1, 2], [60, 200, 50, 100, 50]),
-            ([5, 5, 5, 5, 5], [80, 40, 30, 20, 20])
+            ([1, 1, 2, 1, 2], [0, 1], [200, 150, 37, 75, 50]),
+            ([5, 1, 2, 1, 2], [1, 3], [60, 200, 50, 100, 50]),
+            ([5, 5, 5, 5, 5], [], [80, 40, 30, 20, 20]),
         ]
     )
-    def test_effective_support(self, costs, expected_effective_support):
+    def test_effective_support(self, costs, allocation, expected_effective_support):
         projects = [Project(chr(ord("a") + idx), costs[idx]) for idx in range(0, 5)]
         instance = Instance(projects, budget_limit=2)
         profile = ApprovalProfile(
@@ -343,12 +344,14 @@ class TestAnalysis(TestCase):
                 ApprovalBallot({projects[4]}),
             ]
         )
-        
-        result = calculate_effective_supports(instance, profile, {"sat_class": Cost_Sat}, 5)
+        budget_allocation = BudgetAllocation(allocation)
+
+        result = calculate_effective_supports(
+            instance, profile, budget_allocation, {"sat_class": Cost_Sat}, 5
+        )
         assert len(result) == len(projects)
         sorted_projects = sorted(list(result), key=lambda proj: proj.name)
 
         for idx, project in enumerate(sorted_projects):
             assert project.name == chr(ord("a") + idx)
             assert result[project] == expected_effective_support[idx]
-

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -504,7 +504,8 @@ class TestRule(TestCase):
         with self.assertRaises(ValueError):
             method_of_equal_shares(Instance(), ApprovalProfile())
 
-    def test_iterated_exhaustion(self):
+    @parameterized.expand([(True,), (False,)])
+    def test_iterated_exhaustion(self, exhaustive_stop):
         projects = [
             Project("a", 1),
             Project("b", 1),
@@ -540,6 +541,7 @@ class TestRule(TestCase):
             method_of_equal_shares,
             {"sat_class": Cost_Sat},
             budget_step=frac(1, 24),
+            exhaustive_stop=exhaustive_stop
         )
         assert sorted(budget_allocation_mes_iterated) == [
             projects[0],
@@ -555,6 +557,7 @@ class TestRule(TestCase):
             {"sat_class": Cost_Sat},
             budget_step=frac(1, 24),
             initial_budget_allocation=[projects[6]],
+            exhaustive_stop=exhaustive_stop
         )
         assert sorted(budget_allocation_mes_iterated) == [
             projects[0],
@@ -569,6 +572,7 @@ class TestRule(TestCase):
             method_of_equal_shares,
             {"sat_class": Cost_Sat},
             budget_step=5,
+            exhaustive_stop=exhaustive_stop
         )
         assert budget_allocation_mes_iterated_big_steps == [projects[0]]
 


### PR DESCRIPTION
This minor change allows for running exhaustion MES with only a non-feasibility stop condition, which is exactly how the recent election in Swiecie was run. Other than that there are some minor fixes in project loss & effective support calculation