### PR TITLE
Add Stable-Priceability condition relaxation methods

### DIFF
--- a/pabutools/analysis/priceability.py
+++ b/pabutools/analysis/priceability.py
@@ -61,6 +61,9 @@ def validate_price_system(
         exhaustive : bool, optional
             Verify for exhaustiveness of the allocation.
             Defaults to `True`.
+        relaxation : :py:class:`~pabutools.analysis.priceability_relaxation.Relaxation`, optional
+            Relaxation method to the stable-priceability condition.
+            Defaults to `None`.
         **verbose : bool, optional
             Display additional information.
             Defaults to `False`.
@@ -262,6 +265,9 @@ def priceable(
         exhaustive : bool, optional
             Search exhaustive allocation.
             Defaults to `True`.
+        relaxation : :py:class:`~pabutools.analysis.priceability_relaxation.Relaxation`, optional
+            Relaxation method to the stable-priceability condition.
+            Defaults to `None`.
         **max_seconds : int, optional
             Model's maximum runtime in seconds.
             Defaults to 600.

--- a/pabutools/analysis/priceability.py
+++ b/pabutools/analysis/priceability.py
@@ -280,7 +280,7 @@ def priceable(
         mip_model += b == voter_budget
 
     # payment functions
-    p_vars = [{c: mip_model.add_var(name=f"p_{i.name}_{c.name}") for c in C} for i in N]
+    p_vars = [{c: mip_model.add_var(name=f"p_{idx}_{c.name}") for c in C} for idx, i in enumerate(N)]
     if payment_functions is not None:
         for idx, _ in enumerate(N):
             for c in C:
@@ -334,7 +334,7 @@ def priceable(
             mip_model += p_vars[idx][c] <= x_vars[c] * INF
 
     if not stable:
-        r_vars = [mip_model.add_var(name=f"r_{i.name}") for i in N]
+        r_vars = [mip_model.add_var(name=f"r_{idx}") for idx, i in enumerate(N)]
         for idx, _ in enumerate(N):
             mip_model += r_vars[idx] == b - xsum(p_vars[idx][c] for c in C)
 
@@ -345,7 +345,7 @@ def priceable(
                 <= c.cost + x_vars[c] * INF
             )
     else:
-        m_vars = [mip_model.add_var(name=f"m_{i.name}") for i in N]
+        m_vars = [mip_model.add_var(name=f"m_{idx}") for idx, i in enumerate(N)]
         for idx, _ in enumerate(N):
             for c in C:
                 mip_model += m_vars[idx] >= p_vars[idx][c]

--- a/pabutools/analysis/priceability.py
+++ b/pabutools/analysis/priceability.py
@@ -295,7 +295,10 @@ def priceable(
         mip_model += b == voter_budget
 
     # payment functions
-    p_vars = [{c: mip_model.add_var(name=f"p_{idx}_{c.name}") for c in C} for idx, i in enumerate(N)]
+    p_vars = [
+        {c: mip_model.add_var(name=f"p_{idx}_{c.name}") for c in C}
+        for idx, i in enumerate(N)
+    ]
     if payment_functions is not None:
         for idx, _ in enumerate(N):
             for c in C:
@@ -417,6 +420,8 @@ def priceable(
         status=status,
         allocation=list(sorted([c for c in C if x_vars[c].x >= 0.99])),
         voter_budget=b.x,
-        relaxation_beta=relaxation.get_beta(mip_model) if relaxation is not None else None,
+        relaxation_beta=relaxation.get_beta(mip_model)
+        if relaxation is not None
+        else None,
         payment_functions=payment_functions,
     )

--- a/pabutools/analysis/priceability_relaxation.py
+++ b/pabutools/analysis/priceability_relaxation.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import collections
+from abc import ABC, abstractmethod
+
+from mip import Model, xsum, minimize
+
+from pabutools.election import (
+    Instance,
+    Profile,
+    Project,
+)
+
+
+class Relaxation(ABC):
+    def __init__(self, instance: Instance, profile: Profile):
+        self.instance = self.C = instance
+        self.profile = self.N = profile
+        self.INF = instance.budget_limit * 10
+        self._saved_beta = None
+
+    @abstractmethod
+    def add_beta(self, mip_model: Model) -> None:
+        pass
+
+    @abstractmethod
+    def add_objective(self, mip_model: Model) -> None:
+        pass
+
+    @abstractmethod
+    def add_stability_constraint(self, mip_model: Model) -> None:
+        pass
+
+    @abstractmethod
+    def get_beta(self, mip_model: Model):
+        pass
+
+    @abstractmethod
+    def get_relaxed_cost(self, project: Project) -> float:
+        pass
+
+
+class MinMul(Relaxation):
+    def add_beta(self, mip_model: Model) -> None:
+        mip_model.add_var(name="beta")
+
+    def add_objective(self, mip_model: Model) -> None:
+        beta = mip_model.var_by_name(name="beta")
+        mip_model.objective = minimize(beta)
+
+    def add_stability_constraint(self, mip_model: Model) -> None:
+        x_vars = {c: mip_model.var_by_name(name=f"x_{c.name}") for c in self.C}
+        m_vars = [mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)]
+        beta = mip_model.var_by_name(name="beta")
+        for c in self.C:
+            mip_model += xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i) <= c.cost * beta + x_vars[c] * self.INF
+
+    def get_beta(self, mip_model: Model):
+        beta = mip_model.var_by_name(name="beta")
+        self._saved_beta = beta.x
+        return self._saved_beta
+
+    def get_relaxed_cost(self, project: Project) -> float:
+        return project.cost * self._saved_beta
+
+class MinAdd(Relaxation):
+    def add_beta(self, mip_model: Model) -> None:
+        mip_model.add_var(name="beta", lb=-self.INF)
+
+    def add_objective(self, mip_model: Model) -> None:
+        beta = mip_model.var_by_name(name="beta")
+        mip_model.objective = minimize(beta)
+
+    def add_stability_constraint(self, mip_model: Model) -> None:
+        x_vars = {c: mip_model.var_by_name(name=f"x_{c.name}") for c in self.C}
+        m_vars = [mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)]
+        beta = mip_model.var_by_name(name="beta")
+        for c in self.C:
+            mip_model += xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i) <= c.cost + beta + x_vars[c] * self.INF
+
+    def get_beta(self, mip_model: Model):
+        beta = mip_model.var_by_name(name="beta")
+        self._saved_beta = beta.x
+        return self._saved_beta
+
+    def get_relaxed_cost(self, project: Project) -> float:
+        return project.cost + self._saved_beta
+
+class MinAddVector(Relaxation):
+    def add_beta(self, mip_model: Model) -> None:
+        beta = {c: mip_model.add_var(name=f"beta_{c.name}", lb=-self.INF) for c in self.C}
+        x_vars = {c: mip_model.var_by_name(name=f"x_{c.name}") for c in self.C}
+        # beta[c] is zero for selected
+        for c in self.C:
+            mip_model += beta[c] <= (1 - x_vars[c]) * self.instance.budget_limit
+            mip_model += (x_vars[c] - 1) * self.instance.budget_limit <= beta[c]
+
+    def add_objective(self, mip_model: Model) -> None:
+        beta = {c: mip_model.var_by_name(name=f"beta_{c.name}") for c in self.C}
+        mip_model.objective = minimize(xsum(beta[c] for c in self.C))
+
+    def add_stability_constraint(self, mip_model: Model) -> None:
+        x_vars = {c: mip_model.var_by_name(name=f"x_{c.name}") for c in self.C}
+        m_vars = [mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)]
+        beta = {c: mip_model.var_by_name(name=f"beta_{c.name}") for c in self.C}
+        for c in self.C:
+            mip_model += xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i) <= c.cost + beta[c] + x_vars[c] * self.INF
+
+    def get_beta(self, mip_model: Model):
+        beta = {c: mip_model.var_by_name(name=f"beta_{c.name}") for c in self.C}
+        return_beta = collections.defaultdict(int)
+        for c in self.C:
+            if beta[c].x:
+                return_beta[c] = beta[c].x
+        self._saved_beta = {"beta": return_beta, "sum": sum(return_beta.values())}
+        return self._saved_beta
+
+    def get_relaxed_cost(self, project: Project) -> float:
+        return project.cost + self._saved_beta["beta"][project]
+
+
+class MinAddVectorPositive(MinAddVector):
+    def add_beta(self, mip_model: Model) -> None:
+        _beta = {c: mip_model.add_var(name=f"beta_{c.name}") for c in self.C}
+
+
+class MinAddOffset(Relaxation):
+    BUDGET_FRACTION = 0.025
+
+    def add_beta(self, mip_model: Model) -> None:
+        _beta_global = mip_model.add_var(name="beta", lb=-self.INF)
+        beta = {c: mip_model.add_var(name=f"beta_{c.name}") for c in self.C}
+        mip_model += xsum(beta[c] for c in self.C) <= self.BUDGET_FRACTION * self.instance.budget_limit
+
+    def add_objective(self, mip_model: Model) -> None:
+        beta_global = mip_model.var_by_name(name="beta")
+        mip_model.objective = minimize(beta_global)
+
+    def add_stability_constraint(self, mip_model: Model) -> None:
+        x_vars = {c: mip_model.var_by_name(name=f"x_{c.name}") for c in self.C}
+        m_vars = [mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)]
+        beta_global = mip_model.var_by_name(name="beta")
+        beta = {c: mip_model.var_by_name(name=f"beta_{c.name}") for c in self.C}
+        for c in self.C:
+            mip_model += xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i) <= c.cost + beta_global + beta[c] + x_vars[c] * self.INF
+
+    def get_beta(self, mip_model: Model):
+        beta_global = mip_model.var_by_name(name="beta")
+        beta = {c: mip_model.var_by_name(name=f"beta_{c.name}") for c in self.C}
+        return_beta = collections.defaultdict(int)
+        for c in self.C:
+            if beta[c].x:
+                return_beta[c] = beta[c].x
+        self._saved_beta = {"beta": return_beta, "beta_global": beta_global.x, "sum": sum(return_beta.values())}
+        return self._saved_beta
+
+    def get_relaxed_cost(self, project: Project) -> float:
+        return project.cost + self._saved_beta["beta_global"] + self._saved_beta["beta"][project]

--- a/pabutools/analysis/priceability_relaxation.py
+++ b/pabutools/analysis/priceability_relaxation.py
@@ -114,10 +114,15 @@ class MinMul(Relaxation):
 
     def add_stability_constraint(self, mip_model: Model) -> None:
         x_vars = {c: mip_model.var_by_name(name=f"x_{c.name}") for c in self.C}
-        m_vars = [mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)]
+        m_vars = [
+            mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)
+        ]
         beta = mip_model.var_by_name(name="beta")
         for c in self.C:
-            mip_model += xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i) <= c.cost * beta + x_vars[c] * self.INF
+            mip_model += (
+                xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i)
+                <= c.cost * beta + x_vars[c] * self.INF
+            )
 
     def get_beta(self, mip_model: Model):
         beta = mip_model.var_by_name(name="beta")
@@ -143,10 +148,15 @@ class MinAdd(Relaxation):
 
     def add_stability_constraint(self, mip_model: Model) -> None:
         x_vars = {c: mip_model.var_by_name(name=f"x_{c.name}") for c in self.C}
-        m_vars = [mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)]
+        m_vars = [
+            mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)
+        ]
         beta = mip_model.var_by_name(name="beta")
         for c in self.C:
-            mip_model += xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i) <= c.cost + beta + x_vars[c] * self.INF
+            mip_model += (
+                xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i)
+                <= c.cost + beta + x_vars[c] * self.INF
+            )
 
     def get_beta(self, mip_model: Model):
         beta = mip_model.var_by_name(name="beta")
@@ -164,7 +174,9 @@ class MinAddVector(Relaxation):
     """
 
     def add_beta(self, mip_model: Model) -> None:
-        beta = {c: mip_model.add_var(name=f"beta_{c.name}", lb=-self.INF) for c in self.C}
+        beta = {
+            c: mip_model.add_var(name=f"beta_{c.name}", lb=-self.INF) for c in self.C
+        }
         x_vars = {c: mip_model.var_by_name(name=f"x_{c.name}") for c in self.C}
         # beta[c] is zero for selected
         for c in self.C:
@@ -177,10 +189,15 @@ class MinAddVector(Relaxation):
 
     def add_stability_constraint(self, mip_model: Model) -> None:
         x_vars = {c: mip_model.var_by_name(name=f"x_{c.name}") for c in self.C}
-        m_vars = [mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)]
+        m_vars = [
+            mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)
+        ]
         beta = {c: mip_model.var_by_name(name=f"beta_{c.name}") for c in self.C}
         for c in self.C:
-            mip_model += xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i) <= c.cost + beta[c] + x_vars[c] * self.INF
+            mip_model += (
+                xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i)
+                <= c.cost + beta[c] + x_vars[c] * self.INF
+            )
 
     def get_beta(self, mip_model: Model):
         beta = {c: mip_model.var_by_name(name=f"beta_{c.name}") for c in self.C}
@@ -219,7 +236,10 @@ class MinAddOffset(Relaxation):
     def add_beta(self, mip_model: Model) -> None:
         _beta_global = mip_model.add_var(name="beta", lb=-self.INF)
         beta = {c: mip_model.add_var(name=f"beta_{c.name}") for c in self.C}
-        mip_model += xsum(beta[c] for c in self.C) <= self.BUDGET_FRACTION * self.instance.budget_limit
+        mip_model += (
+            xsum(beta[c] for c in self.C)
+            <= self.BUDGET_FRACTION * self.instance.budget_limit
+        )
 
     def add_objective(self, mip_model: Model) -> None:
         beta_global = mip_model.var_by_name(name="beta")
@@ -227,11 +247,16 @@ class MinAddOffset(Relaxation):
 
     def add_stability_constraint(self, mip_model: Model) -> None:
         x_vars = {c: mip_model.var_by_name(name=f"x_{c.name}") for c in self.C}
-        m_vars = [mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)]
+        m_vars = [
+            mip_model.var_by_name(name=f"m_{idx}") for idx, _ in enumerate(self.N)
+        ]
         beta_global = mip_model.var_by_name(name="beta")
         beta = {c: mip_model.var_by_name(name=f"beta_{c.name}") for c in self.C}
         for c in self.C:
-            mip_model += xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i) <= c.cost + beta_global + beta[c] + x_vars[c] * self.INF
+            mip_model += (
+                xsum(m_vars[idx] for idx, i in enumerate(self.N) if c in i)
+                <= c.cost + beta_global + beta[c] + x_vars[c] * self.INF
+            )
 
     def get_beta(self, mip_model: Model):
         beta_global = mip_model.var_by_name(name="beta")
@@ -240,8 +265,16 @@ class MinAddOffset(Relaxation):
         for c in self.C:
             if beta[c].x:
                 return_beta[c] = beta[c].x
-        self._saved_beta = {"beta": return_beta, "beta_global": beta_global.x, "sum": sum(return_beta.values())}
+        self._saved_beta = {
+            "beta": return_beta,
+            "beta_global": beta_global.x,
+            "sum": sum(return_beta.values()),
+        }
         return self._saved_beta
 
     def get_relaxed_cost(self, project: Project) -> float:
-        return project.cost + self._saved_beta["beta_global"] + self._saved_beta["beta"][project]
+        return (
+            project.cost
+            + self._saved_beta["beta_global"]
+            + self._saved_beta["beta"][project]
+        )

--- a/pabutools/analysis/priceability_relaxation.py
+++ b/pabutools/analysis/priceability_relaxation.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import collections
 from abc import ABC, abstractmethod
+from numbers import Real
 
 from mip import Model, xsum, minimize
 
@@ -76,7 +77,7 @@ class Relaxation(ABC):
         """
 
     @abstractmethod
-    def get_beta(self, mip_model: Model):
+    def get_beta(self, mip_model: Model) -> Real | dict:
         """
         Get the value of beta from the model.
         This method implicitly saves internally the value of beta variable from `mip_model`.
@@ -85,6 +86,12 @@ class Relaxation(ABC):
         ----------
             mip_model : Model
                 The stable-priceability MIP model.
+
+        Returns
+        -------
+            Real | dict
+                The value of beta from the model.
+
         """
 
     @abstractmethod
@@ -96,6 +103,12 @@ class Relaxation(ABC):
         ----------
             project : :py:class:`~pabutools.election.instance.Project`
                 The project to get the relaxed cost for.
+
+        Returns
+        -------
+            float
+                Relaxed cost of the project.
+
         """
 
 
@@ -124,7 +137,7 @@ class MinMul(Relaxation):
                 <= c.cost * beta + x_vars[c] * self.INF
             )
 
-    def get_beta(self, mip_model: Model):
+    def get_beta(self, mip_model: Model) -> Real | dict:
         beta = mip_model.var_by_name(name="beta")
         self._saved_beta = beta.x
         return self._saved_beta
@@ -158,7 +171,7 @@ class MinAdd(Relaxation):
                 <= c.cost + beta + x_vars[c] * self.INF
             )
 
-    def get_beta(self, mip_model: Model):
+    def get_beta(self, mip_model: Model) -> Real | dict:
         beta = mip_model.var_by_name(name="beta")
         self._saved_beta = beta.x
         return self._saved_beta
@@ -199,7 +212,7 @@ class MinAddVector(Relaxation):
                 <= c.cost + beta[c] + x_vars[c] * self.INF
             )
 
-    def get_beta(self, mip_model: Model):
+    def get_beta(self, mip_model: Model) -> Real | dict:
         beta = {c: mip_model.var_by_name(name=f"beta_{c.name}") for c in self.C}
         return_beta = collections.defaultdict(int)
         for c in self.C:
@@ -258,7 +271,7 @@ class MinAddOffset(Relaxation):
                 <= c.cost + beta_global + beta[c] + x_vars[c] * self.INF
             )
 
-    def get_beta(self, mip_model: Model):
+    def get_beta(self, mip_model: Model) -> Real | dict:
         beta_global = mip_model.var_by_name(name="beta")
         beta = {c: mip_model.var_by_name(name=f"beta_{c.name}") for c in self.C}
         return_beta = collections.defaultdict(int)


### PR DESCRIPTION
Add relaxation methods for **stable-priceability** condition, which can be used to:
- measure "how stable-priceable" an allocation is,
- find allocations that fulfill in fact stronger proportionality condition than stable-priceablity.
---

Will add a guide to the documentation in a future PR.

